### PR TITLE
Add comprehensive Docusaurus documentation with proper sidebar positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,15 @@
 [![GitHub license](https://img.shields.io/github/license/byjg/php-redis-queue-client.svg)](https://opensource.byjg.com/opensource/licensing.html)
 [![GitHub release](https://img.shields.io/github/release/byjg/php-redis-queue-client.svg)](https://github.com/byjg/php-redis-queue-client/releases/)
 
-It creates a simple abstraction layer to publish and consume messages from the Redis using the component [byjg/message-queue-client](https://github.com/byjg/message-queue-client).
+A simple and efficient abstraction layer for publishing and consuming messages from Redis queues using the [byjg/message-queue-client](https://github.com/byjg/message-queue-client) framework.
 
-For details on how to use the Message Queue Client see the [documentation](https://github.com/byjg/message-queue-client)
+## Documentation
+
+- [Installation](docs/installation.md)
+- [Connection](docs/connection.md)
+- [Publishing Messages](docs/publishing.md)
+- [Consuming Messages](docs/consuming.md)
+- [Error Handling](docs/error-handling.md)
 
 ## Usage
 
@@ -75,18 +81,18 @@ Possible return values from the callback function:
 * `Message::REQUEUE` - Requeue the message
 * `Message::EXIT` - Exit the consume method
 
-## Protocols:
+## Protocols
 
-| Protocol | URI Example                                         | Notes                                                                                  |
-|----------|-----------------------------------------------------|----------------------------------------------------------------------------------------|
-| Redis    | redis://user:pass@host:port                         | Default port: 6379.                                                                    |
+| Protocol | URI Example                 | Notes               |
+|----------|-----------------------------|---------------------|
+| Redis    | redis://user:pass@host:port | Default port: 6379  |
 
 ## Dependencies
 
 ```mermaid
 flowchart TD
     byjg/redis-queue-client --> byjg/message-queue-client
-    byjg/redis-queue-client --> ext-redis
 ```
+
 ----
 [Open source ByJG](http://opensource.byjg.com)

--- a/docs/connection.md
+++ b/docs/connection.md
@@ -1,0 +1,74 @@
+---
+sidebar_position: 2
+---
+
+# Connection
+
+## Registering the Connector
+
+Before using the Redis Queue Client, you need to register the connector with the ConnectorFactory:
+
+```php
+<?php
+use ByJG\MessageQueueClient\ConnectorFactory;
+use ByJG\MessageQueueClient\RedisQueue\RedisQueueConnector;
+
+ConnectorFactory::registerConnector(RedisQueueConnector::class);
+```
+
+## Creating a Connection
+
+Create a connector instance using a Redis URI:
+
+```php
+<?php
+use ByJG\MessageQueueClient\ConnectorFactory;
+use ByJG\Util\Uri;
+
+$connector = ConnectorFactory::create(new Uri("redis://$user:$pass@$host:$port"));
+```
+
+## Connection URI Format
+
+The Redis connection URI follows this format:
+
+```
+redis://[user[:password]@]host[:port]
+```
+
+### Parameters
+
+- **user** (optional): Redis username (ACL authentication)
+- **password** (optional): Redis password
+- **host** (required): Redis server hostname or IP address
+- **port** (optional): Redis server port (default: 6379)
+
+### Examples
+
+**Simple connection without authentication:**
+```php
+$connector = ConnectorFactory::create(new Uri("redis://localhost:6379"));
+```
+
+**Connection with password only:**
+```php
+$connector = ConnectorFactory::create(new Uri("redis://:mypassword@localhost:6379"));
+```
+
+**Connection with username and password (ACL):**
+```php
+$connector = ConnectorFactory::create(new Uri("redis://myuser:mypassword@localhost:6379"));
+```
+
+**Using default port (6379):**
+```php
+$connector = ConnectorFactory::create(new Uri("redis://localhost"));
+```
+
+## Connection Features
+
+The connector automatically:
+- Uses lazy loading for the Redis connection
+- Configures serialization to `SERIALIZER_NONE` for plain text message handling
+- Authenticates using username/password when provided
+- Validates the connection by checking the Redis version

--- a/docs/consuming.md
+++ b/docs/consuming.md
@@ -1,0 +1,194 @@
+---
+sidebar_position: 4
+---
+
+# Consuming Messages
+
+The consume method allows you to process messages from a Redis queue. It will continuously wait for messages and process them using callback functions.
+
+## Basic Consumption
+
+```php
+<?php
+use ByJG\MessageQueueClient\ConnectorFactory;
+use ByJG\MessageQueueClient\Connector\Pipe;
+use ByJG\MessageQueueClient\Envelope;
+use ByJG\MessageQueueClient\Message;
+use ByJG\MessageQueueClient\RedisQueue\RedisQueueConnector;
+use ByJG\Util\Uri;
+
+// Register and create connector
+ConnectorFactory::registerConnector(RedisQueueConnector::class);
+$connector = ConnectorFactory::create(new Uri("redis://localhost:6379"));
+
+// Create a queue
+$pipe = new Pipe("test");
+$pipe->withDeadLetter(new Pipe("dlq_test"));
+
+// Start consuming
+$connector->consume(
+    $pipe,
+    function (Envelope $envelope) {
+        echo "Processing message: " . $envelope->getMessage()->getBody();
+        return Message::ACK;
+    },
+    function (Envelope $envelope, $ex) {
+        echo "Error: " . $ex->getMessage();
+        return Message::REQUEUE;
+    }
+);
+```
+
+## Callback Functions
+
+The consume method requires two callback functions:
+
+### Success Callback
+
+Called when a message is successfully retrieved:
+
+```php
+function (Envelope $envelope) {
+    // Access message body
+    $body = $envelope->getMessage()->getBody();
+
+    // Process the message
+    // ... your logic here ...
+
+    // Return action to take
+    return Message::ACK;
+}
+```
+
+### Error Callback
+
+Called when an exception or error occurs during message processing:
+
+```php
+function (Envelope $envelope, Exception|Error $ex) {
+    // Log the error
+    error_log($ex->getMessage());
+
+    // Access the message that caused the error
+    $body = $envelope->getMessage()->getBody();
+
+    // Return action to take
+    return Message::REQUEUE;
+}
+```
+
+## Return Values
+
+Control message flow by returning one or more of these constants:
+
+### Single Actions
+
+- **`Message::ACK`** - Acknowledge and remove the message from the queue
+- **`Message::NACK`** - Not acknowledge the message. If a dead letter queue is configured, the message will be sent there
+- **`Message::REQUEUE`** - Put the message back into the queue for reprocessing
+- **`Message::EXIT`** - Stop consuming and exit the consume loop
+
+### Combined Actions
+
+You can combine actions using the bitwise OR operator (`|`):
+
+```php
+// Acknowledge the message AND exit the consumer
+return Message::ACK | Message::EXIT;
+```
+
+```php
+// Requeue the message AND exit the consumer
+return Message::REQUEUE | Message::EXIT;
+```
+
+## Examples
+
+### Simple Message Processing
+
+```php
+$connector->consume(
+    $pipe,
+    function (Envelope $envelope) {
+        $data = json_decode($envelope->getMessage()->getBody(), true);
+
+        // Process data
+        processData($data);
+
+        return Message::ACK;
+    },
+    function (Envelope $envelope, $ex) {
+        error_log("Failed to process: " . $ex->getMessage());
+        return Message::NACK; // Send to dead letter queue
+    }
+);
+```
+
+### Processing with Exit Condition
+
+```php
+$processedCount = 0;
+
+$connector->consume(
+    $pipe,
+    function (Envelope $envelope) use (&$processedCount) {
+        $body = $envelope->getMessage()->getBody();
+
+        // Process message
+        processMessage($body);
+        $processedCount++;
+
+        // Exit after processing 100 messages
+        if ($processedCount >= 100) {
+            return Message::ACK | Message::EXIT;
+        }
+
+        return Message::ACK;
+    },
+    function (Envelope $envelope, $ex) {
+        error_log($ex->getMessage());
+        return Message::REQUEUE;
+    }
+);
+```
+
+### Conditional Requeuing
+
+```php
+$connector->consume(
+    $pipe,
+    function (Envelope $envelope) {
+        $data = json_decode($envelope->getMessage()->getBody(), true);
+
+        if (shouldProcessNow($data)) {
+            processData($data);
+            return Message::ACK;
+        } else {
+            // Not ready to process, put it back
+            return Message::REQUEUE;
+        }
+    },
+    function (Envelope $envelope, $ex) {
+        // On error, send to dead letter queue
+        return Message::NACK;
+    }
+);
+```
+
+## Blocking Behavior
+
+The `consume()` method uses Redis `BRPOP` (blocking right pop):
+- It will **block and wait** indefinitely until a message becomes available
+- The timeout is set to 0, meaning it waits forever for the next message
+- This is efficient as it doesn't poll the queue constantly
+- The loop continues until you return `Message::EXIT` or the process is terminated
+
+## Identification Parameter
+
+The consume method accepts an optional `$identification` parameter (currently not used by Redis connector):
+
+```php
+$connector->consume($pipe, $onReceive, $onError, "worker-1");
+```
+
+This parameter is part of the interface for compatibility with other queue connectors.

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,275 @@
+---
+sidebar_position: 5
+---
+
+# Error Handling
+
+The Redis Queue Client provides robust error handling mechanisms to manage failed messages and ensure message reliability.
+
+## Dead Letter Queues
+
+A Dead Letter Queue (DLQ) is a separate queue that stores messages that cannot be processed successfully.
+
+### Configuring a DLQ
+
+Attach a dead letter queue to your main pipe:
+
+```php
+use ByJG\MessageQueueClient\Connector\Pipe;
+
+$mainPipe = new Pipe("orders");
+$mainPipe->withDeadLetter(new Pipe("dlq_orders"));
+```
+
+### When Messages Go to DLQ
+
+Messages are sent to the dead letter queue when the consumer returns `Message::NACK`:
+
+```php
+$connector->consume(
+    $mainPipe,
+    function (Envelope $envelope) {
+        try {
+            processOrder($envelope->getMessage()->getBody());
+            return Message::ACK;
+        } catch (InvalidOrderException $e) {
+            // Permanently failed, send to DLQ
+            return Message::NACK;
+        }
+    },
+    function (Envelope $envelope, $ex) {
+        // Critical error during processing
+        error_log("Critical error: " . $ex->getMessage());
+        return Message::NACK; // Send to DLQ
+    }
+);
+```
+
+## Error Recovery Strategies
+
+### Strategy 1: Requeue for Retry
+
+Use `Message::REQUEUE` for temporary failures:
+
+```php
+$connector->consume(
+    $pipe,
+    function (Envelope $envelope) {
+        return Message::ACK;
+    },
+    function (Envelope $envelope, $ex) {
+        if ($ex instanceof TemporaryException) {
+            // Temporary issue, try again
+            return Message::REQUEUE;
+        }
+
+        // Permanent failure, send to DLQ
+        return Message::NACK;
+    }
+);
+```
+
+:::caution
+Be careful with `REQUEUE` - it can cause infinite loops if the failure condition persists. Consider implementing retry limits in your application logic.
+:::
+
+### Strategy 2: Dead Letter Queue
+
+Use `Message::NACK` for permanent failures:
+
+```php
+$connector->consume(
+    $pipe,
+    function (Envelope $envelope) {
+        $data = json_decode($envelope->getMessage()->getBody(), true);
+
+        if (!validateData($data)) {
+            // Invalid data, don't requeue
+            return Message::NACK;
+        }
+
+        processData($data);
+        return Message::ACK;
+    },
+    function (Envelope $envelope, $ex) {
+        error_log("Processing failed: " . $ex->getMessage());
+        return Message::NACK;
+    }
+);
+```
+
+### Strategy 3: Acknowledge and Log
+
+Sometimes you want to acknowledge a message even if processing failed:
+
+```php
+$connector->consume(
+    $pipe,
+    function (Envelope $envelope) {
+        return Message::ACK;
+    },
+    function (Envelope $envelope, $ex) {
+        // Log the error
+        error_log("Error: " . $ex->getMessage());
+
+        // Store in database for manual review
+        logFailedMessage($envelope->getMessage()->getBody(), $ex);
+
+        // Acknowledge anyway to prevent reprocessing
+        return Message::ACK;
+    }
+);
+```
+
+## Processing DLQ Messages
+
+You can consume messages from the dead letter queue for manual inspection or reprocessing:
+
+```php
+$dlqPipe = new Pipe("dlq_orders");
+
+$connector->consume(
+    $dlqPipe,
+    function (Envelope $envelope) {
+        $body = $envelope->getMessage()->getBody();
+
+        // Log or store for manual review
+        logFailedMessage($body);
+
+        // Try to fix and republish to main queue if possible
+        if (canBeFixed($body)) {
+            $fixedMessage = fixMessage($body);
+            $mainPipe = new Pipe("orders");
+            $connector->publish(new Envelope($mainPipe, new Message($fixedMessage)));
+        }
+
+        return Message::ACK;
+    },
+    function (Envelope $envelope, $ex) {
+        // Even DLQ processing can fail
+        error_log("DLQ processing error: " . $ex->getMessage());
+        return Message::ACK; // Don't requeue DLQ messages
+    }
+);
+```
+
+## Exception Types
+
+The error callback receives any `Exception` or `Error` thrown during message processing:
+
+```php
+function (Envelope $envelope, Exception|Error $ex) {
+    // Handle different error types
+    if ($ex instanceof \Redis\Exception) {
+        // Redis connection issue
+        return Message::REQUEUE;
+    }
+
+    if ($ex instanceof \JsonException) {
+        // Invalid JSON, can't be fixed
+        return Message::NACK;
+    }
+
+    // Default: send to DLQ
+    return Message::NACK;
+}
+```
+
+## Best Practices
+
+### 1. Always Configure a DLQ
+
+```php
+// Good: Has DLQ configured
+$pipe = new Pipe("important-queue");
+$pipe->withDeadLetter(new Pipe("dlq_important-queue"));
+```
+
+### 2. Implement Comprehensive Logging
+
+```php
+$connector->consume(
+    $pipe,
+    function (Envelope $envelope) {
+        $startTime = microtime(true);
+
+        try {
+            $result = processMessage($envelope->getMessage()->getBody());
+
+            $duration = microtime(true) - $startTime;
+            logger()->info("Message processed", [
+                'duration' => $duration,
+                'result' => $result
+            ]);
+
+            return Message::ACK;
+        } catch (Exception $ex) {
+            logger()->error("Processing failed", [
+                'error' => $ex->getMessage(),
+                'message' => $envelope->getMessage()->getBody()
+            ]);
+            throw $ex; // Will be caught by error callback
+        }
+    },
+    function (Envelope $envelope, $ex) {
+        logger()->critical("Message error", [
+            'exception' => get_class($ex),
+            'message' => $ex->getMessage(),
+            'trace' => $ex->getTraceAsString()
+        ]);
+
+        return Message::NACK;
+    }
+);
+```
+
+### 3. Distinguish Between Temporary and Permanent Failures
+
+```php
+function (Envelope $envelope, $ex) {
+    // Temporary failures - retry
+    if ($ex instanceof NetworkException || $ex instanceof TimeoutException) {
+        return Message::REQUEUE;
+    }
+
+    // Permanent failures - DLQ
+    if ($ex instanceof ValidationException || $ex instanceof DataException) {
+        return Message::NACK;
+    }
+
+    // Unknown - send to DLQ for investigation
+    return Message::NACK;
+}
+```
+
+### 4. Monitor Your DLQ
+
+Set up monitoring and alerts for your dead letter queues:
+
+```php
+// Periodically check DLQ depth
+$dlqSize = $connector->getDriver()->llen("dlq_orders");
+
+if ($dlqSize > 100) {
+    sendAlert("DLQ size exceeded threshold: $dlqSize messages");
+}
+```
+
+## Redis Connection Errors
+
+Connection errors to Redis will throw `RedisException`:
+
+```php
+use RedisException;
+
+try {
+    $connector->consume($pipe, $onReceive, $onError);
+} catch (RedisException $ex) {
+    // Redis connection lost
+    error_log("Redis connection error: " . $ex->getMessage());
+
+    // Implement reconnection logic
+    sleep(5);
+    // retry...
+}
+```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,32 @@
+---
+sidebar_position: 1
+---
+
+# Installation
+
+## Requirements
+
+- PHP 8.1 or higher (up to 8.4)
+- Redis PHP extension (`ext-redis`)
+- cURL PHP extension (`ext-curl`)
+
+## Installing via Composer
+
+Install the package using Composer:
+
+```bash
+composer require byjg/redis-queue-client
+```
+
+This will automatically install the required dependencies, including:
+- `byjg/message-queue-client` - The base message queue client framework
+
+## Verifying Installation
+
+After installation, verify that the Redis extension is enabled:
+
+```bash
+php -m | grep redis
+```
+
+You should see `redis` in the output.

--- a/docs/publishing.md
+++ b/docs/publishing.md
@@ -1,0 +1,93 @@
+---
+sidebar_position: 3
+---
+
+# Publishing Messages
+
+Publishing messages to a Redis queue involves creating a pipe (queue), a message, and an envelope to wrap them together.
+
+## Basic Publishing
+
+```php
+<?php
+use ByJG\MessageQueueClient\ConnectorFactory;
+use ByJG\MessageQueueClient\Connector\Pipe;
+use ByJG\MessageQueueClient\Message;
+use ByJG\MessageQueueClient\Envelope;
+use ByJG\MessageQueueClient\RedisQueue\RedisQueueConnector;
+use ByJG\Util\Uri;
+
+// Register and create connector
+ConnectorFactory::registerConnector(RedisQueueConnector::class);
+$connector = ConnectorFactory::create(new Uri("redis://localhost:6379"));
+
+// Create a queue (pipe)
+$pipe = new Pipe("test");
+
+// Create a message
+$message = new Message("Hello World");
+
+// Publish the message
+$connector->publish(new Envelope($pipe, $message));
+```
+
+## Creating a Pipe
+
+A pipe represents a queue in Redis. Create it with a queue name:
+
+```php
+$pipe = new Pipe("my-queue-name");
+```
+
+### Pipe with Dead Letter Queue
+
+You can configure a dead letter queue (DLQ) to handle failed messages:
+
+```php
+$pipe = new Pipe("test");
+$pipe->withDeadLetter(new Pipe("dlq_test"));
+```
+
+When a message is not acknowledged (NACK), it will be sent to the dead letter queue.
+
+## Creating a Message
+
+Messages are created with a body (string content):
+
+```php
+// Simple text message
+$message = new Message("Hello World");
+
+// JSON message
+$message = new Message(json_encode(['key' => 'value']));
+
+// Any string content
+$message = new Message("Any text content here");
+```
+
+### Message Properties
+
+Messages support additional properties:
+
+```php
+$message = new Message("Hello");
+$properties = $message->getProperties();
+// Default content_type is 'text/plain'
+```
+
+## Publishing Messages
+
+Wrap the pipe and message in an Envelope and publish:
+
+```php
+$envelope = new Envelope($pipe, $message);
+$connector->publish($envelope);
+```
+
+## How It Works
+
+When you publish a message:
+1. The connector uses Redis `LPUSH` to add the message to the left side of the list
+2. The message body is stored as a plain string (no serialization)
+3. The content type defaults to `text/plain` if not specified
+4. Consumers will retrieve messages from the right side using `BRPOP`


### PR DESCRIPTION
- Created /docs folder with 5 documentation files following Docusaurus best practices
- Each doc file has sidebar_position matching the order in README.md
- Updated README.md with Documentation section linking to all docs
- Fixed Dependencies section to only show byjg projects (removed ext-redis)
- Moved Dependencies section to be last before footer
- Documentation covers: Installation, Connection, Publishing, Consuming, Error Handling
- All sidebar_position values are sequential integers (1-5) matching link order